### PR TITLE
remove duplicate security context definition

### DIFF
--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -54,9 +54,6 @@ spec:
               value: "{{ .Values.prometheusEndpoint }}"
             - name: "POLL_INTERVAL"
               value: "{{ .Values.pollIntervalSeconds }}"
-          securityContext:
-            privileged: true
-            readOnlyRootFilesystem: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Having 2 `securityContext` definitions on the container spec was causing helm to fail deploy due to a duplicate key definition.

This change removes the duplicate key and relies on `privileged` and `readOnlyRootFilesystem` being set in `.Values.securityContext`