### PR TITLE
Add dashboard label for sidecar

### DIFF
--- a/chart/dashboard.json
+++ b/chart/dashboard.json
@@ -359,7 +359,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(caretta_links_observed)",
         "hide": 0,
@@ -390,7 +390,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(caretta_links_observed)",
         "hide": 0,
@@ -421,7 +421,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(caretta_links_observed)",
         "hide": 0,
@@ -453,7 +453,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(server_port)",
         "hide": 0,

--- a/chart/dashboard.json
+++ b/chart/dashboard.json
@@ -24,15 +24,16 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 15,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
+      "description": "",
       "gridPos": {
         "h": 24,
         "w": 17,
@@ -55,7 +56,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -69,7 +70,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -88,7 +89,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -141,7 +142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by (server_port) (increase((caretta_links_observed{client_namespace=~\"$namespace\", client_kind=~\"$kind\", client_name=~\"$workload\", server_port=~\"$port\"} or caretta_links_observed{server_namespace=~\"$namespace\", server_kind=~\"$kind\", server_name=~\"$workload\", server_port=~\"$port\"})[$__range:$__interval])) > 0",
@@ -174,13 +175,13 @@
         "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n     <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \">\n<div style=\"text-align: center\">\n<p align=\"center\">\n  <img src=\"https://raw.githubusercontent.com/groundcover-com/caretta/main/images/logo.svg\" width=\"75%\" alt=\"caretta\" title=\"caretta\" />\n  <h4>by <a href=\"https://www.groundcover.com\">groundcover</h4>\n\n  \n  [![slack](https://img.shields.io/badge/slack-groundcover-yellowgreen.svg?logo=slack)](http://www.groundcover.com/join-slack)\n  \n</div>\n</p>\n</div>\n</td>\n</table>\n",
         "mode": "markdown"
       },
-      "pluginVersion": "9.3.1",
+      "pluginVersion": "10.1.2",
       "type": "text"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -225,14 +226,15 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "valueMode": "color"
       },
-      "pluginVersion": "9.3.1",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -250,7 +252,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -298,12 +300,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.1",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -319,11 +321,31 @@
       "type": "stat"
     }
   ],
-  "schemaVersion": 37,
+  "refresh": "",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "allValue": "(.*)",
         "current": {
@@ -337,7 +359,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "P4169E866C3094E38"
         },
         "definition": "query_result(caretta_links_observed)",
         "hide": 0,
@@ -368,7 +390,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "P4169E866C3094E38"
         },
         "definition": "query_result(caretta_links_observed)",
         "hide": 0,
@@ -399,7 +421,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "P4169E866C3094E38"
         },
         "definition": "query_result(caretta_links_observed)",
         "hide": 0,
@@ -431,7 +453,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "P4169E866C3094E38"
         },
         "definition": "label_values(server_port)",
         "hide": 0,
@@ -460,6 +482,6 @@
   "timezone": "",
   "title": "Caretta Dashboard",
   "uid": "k0Om62pVf",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/chart/templates/grafana/dashboards.yaml
+++ b/chart/templates/grafana/dashboards.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: caretta-grafana-dashboards
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- if $.Values.grafana.sidecar.dashboards.enabled }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
+    {{- end }}
 data: 
   dashboard.json: |-
 {{ .Files.Get "dashboard.json" | indent 4}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,7 +124,12 @@ grafana:
         access: proxy
         url: "http://caretta-vm:8428"
         editable: "true"
-  
+
+  sidecar:
+    dashboards:
+      label: grafana_dashboard
+      labelValue: "" 
+
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1


### PR DESCRIPTION
Add the possibility to add a label to the dashboard configmap so it can be easily imported when using another Grafana instance

Also adds a datasource variable that can be used when not using the provided Victoria-metrics instance