### PR TITLE
Add podmonitor

### DIFF
--- a/chart/templates/monitor/podmonitor.yaml
+++ b/chart/templates/monitor/podmonitor.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "caretta.name" . }}-podmonitor
+  namespace: {{ .Values.podMonitor.namespace | default .Release.Namespace }}
+  {{- with .Values.podMonitor.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- with .Values.podMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.podMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: caretta
+      {{- include "caretta.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - honorLabels: {{ .Values.podMonitor.honorLabels }}
+    port: prom-metrics
+    {{- with .Values.podMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    scheme: http
+    {{- with .Values.podMonitor.endpointAdditionalProperties }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,6 +32,25 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Prometheus PodMonitor configuration -- to install caretta with the PodMonitor
+# you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will
+# have no effect.
+podMonitor:
+  # -- enabled determines whether a podMonitor should be deployed
+  enabled: false
+  # -- The namespace where Prometheus expects to find service monitors
+  namespace: ~
+  # -- Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used.
+  interval: ~
+  # -- Additional annotations for the podMonitor
+  annotations: {}
+  # -- Additional labels for the podMonitor
+  labels: {}
+  # -- HonorLabels chooses the metric’s labels on collisions with target labels
+  honorLabels: true
+  # -- EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.
+  endpointAdditionalProperties: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Add a podmonitor so caretta can easily be used with Prometheus/Victoria Metrics operator when not using the provided Victoria-Metrics instance