### PR TITLE
chore(helm): Add informational comment for psp

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,9 @@ prometheusEndpoint: "/metrics"
 pollIntervalSeconds: 5
 
 rbac:
+  # With the release of Kubernetes v1.25, PodSecurityPolicy has been removed.
+  # You can read more information about the removal of PodSecurityPolicy in the Kubernetes 1.25 release notes.
+  # See: https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/
   pspEnabled: true
   sccEnabled: true
 image:
@@ -83,7 +86,7 @@ victoria-metrics-single:
           scrape_interval: 15s
 
         scrape_configs:
-          - job_name:       'caretta'
+          - job_name: 'caretta'
             metrics_path: /metrics
             scrape_interval: 5s
             kubernetes_sd_configs:


### PR DESCRIPTION
## What's the purpose

Add informational note regarding PodSecurityPolicy (PSP) deprecation and removal

## What it changed

> No actual code changes have been made in this commit.

This PR is intended to inform about the deprecation and removal of the PodSecurityPolicy (PSP) resource.

PSP was officially deprecated in Kubernetes 1.21 and has been removed as of Kubernetes 1.25. PSP was used to enforce security policies on pods at the admission level. However, due to its complexity and various limitations, Kubernetes introduced Pod Security Admission as its replacement.

For those upgrading to Kubernetes 1.25 or later, it's crucial to transition to the newer Pod Security Admission mechanism to maintain pod security standards.

For more details on the PSP removal, you can refer to the Kubernetes official blog post: [PodSecurityPolicy Deprecation: Past, Present, and Future](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).

## Reference

https://github.com/kubernetes/kubernetes/pull/109798